### PR TITLE
Add conditional in case context yields no results

### DIFF
--- a/src/services/Similar.php
+++ b/src/services/Similar.php
@@ -69,6 +69,7 @@ class Similar extends Component
             throw new Exception('Required parameter `context` was not supplied to `craft.similar.find`.');
         }
 
+
         /** @var class-string|Element $element */
         $element = $data['element'];
         $context = $data['context'];
@@ -109,10 +110,15 @@ class Similar extends Component
             $query->andWhere(['elements_sites.siteId' => $element->siteId]);
         }
 
-        $query->andWhere(['in', 'relations.targetId', $tagIds]);
+        // If no tags are provided, skip this and assume all elements are similar
+        if($tagIds){
+            $query->andWhere(['in', 'relations.targetId', $tagIds]);
+        }
+
         $query->leftJoin(['relations' => Table::RELATIONS], '[[elements.id]] = [[relations.sourceId]]');
 
         $results = $query->all();
+
 
         // Fetch the elements based on the returned `id` and `siteId`
         $queryConditions = [];
@@ -136,6 +142,7 @@ class Similar extends Component
                 $similarCounts[$key] = $config['count'];
             }
         }
+
 
         if (empty($results)) {
             return [];
@@ -162,6 +169,7 @@ class Similar extends Component
 
         $elements = $query->all();
 
+
         /** @var Element $element */
         foreach ($elements as $element) {
             // The `count` property is added dynamically by our CountBehavior behavior
@@ -174,7 +182,7 @@ class Similar extends Component
 
         if (empty($criteria['orderBy'])) {
             /** @phpstan-ignore-next-line */
-            usort($elements, static fn($a, $b) => $a->count < $b->count ? 1 : ($a->count == $b->count ? 0 : -1));
+            // usort($elements, static fn($a, $b) => $a->count < $b->count ? 1 : ($a->count == $b->count ? 0 : -1));
         }
 
         return $elements;
@@ -197,7 +205,10 @@ class Similar extends Component
 
         $query->query->groupBy(['relations.sourceId', 'elements.id', 'elements_sites.siteId']);
 
-        $query->query->andWhere(['in', 'relations.targetId', $this->targetElements]);
+        // If targetElements are provided, filter by them, otherwise get anything that matches criteria
+        if($this->targetElements){
+            $query->query->andWhere(['in', 'relations.targetId', $this->targetElements]);
+        }
 
         $query->subQuery->limit(null); // inner limit to null -> fetch all possible entries, sort them afterwards
         $query->query->limit($this->limit); // or whatever limit is set

--- a/src/services/Similar.php
+++ b/src/services/Similar.php
@@ -182,7 +182,7 @@ class Similar extends Component
 
         if (empty($criteria['orderBy'])) {
             /** @phpstan-ignore-next-line */
-            // usort($elements, static fn($a, $b) => $a->count < $b->count ? 1 : ($a->count == $b->count ? 0 : -1));
+            usort($elements, static fn($a, $b) => $a->count < $b->count ? 1 : ($a->count == $b->count ? 0 : -1));
         }
 
         return $elements;


### PR DESCRIPTION
Fixes #55 

This is required after the element query changes in Craft 5.8.15

### Description
This adds a conditional around the relationships `andWhere` tag so it doesn't do that bit of the query if the context yields no results. Effectively this falls back to showing anything that matches the criteria, which in my test seems to yield the same results we had pre 5.8.15.


### Related issues
#55 