### PR TITLE
Fix/limit criteria

### DIFF
--- a/src/services/Similar.php
+++ b/src/services/Similar.php
@@ -68,7 +68,7 @@ class Similar extends Component
         if (!isset($data['context'])) {
             throw new Exception('Required parameter `context` was not supplied to `craft.similar.find`.');
         }
-        
+
         /** @var class-string|Element $element */
         $element = $data['element'];
         $context = $data['context'];
@@ -81,12 +81,19 @@ class Similar extends Component
 
         // Get an ElementQuery for this Element
         $elementClass = is_object($element) ? $element::class : $element;
+
+        // Stash limit and remove from criteria
+        if (isset($criteria['limit'])) {
+            $this->limit = $criteria['limit'];
+            $criteria['limit'] = null;
+        }
+
         /** @var EntryQuery $query */
         $query = $this->getElementQuery($elementClass, $criteria);
 
         // Stash any orderBy directives from the $query for our anonymous function
         $this->preOrder = $query->orderBy ?? [];
-        $this->limit = $query->limit;
+
         // Extract the $tagIds from the $context
         if (is_array($context)) {
             $tagIds = $context;
@@ -181,6 +188,9 @@ class Similar extends Component
         if (empty($criteria['orderBy'])) {
             /** @phpstan-ignore-next-line */
             usort($elements, static fn($a, $b) => $a->count < $b->count ? 1 : ($a->count == $b->count ? 0 : -1));
+        }
+        if ($this->limit) {
+            $elements = array_slice($elements, 0, $this->limit);
         }
 
         return $elements;

--- a/src/services/Similar.php
+++ b/src/services/Similar.php
@@ -209,7 +209,6 @@ class Similar extends Component
         }
 
         $query->subQuery->limit(null); // inner limit to null -> fetch all possible entries, sort them afterwards
-        $query->query->limit($this->limit); // or whatever limit is set
 
         $query->subQuery->groupBy(['elements.id', 'elements_sites.id']);
 


### PR DESCRIPTION
### Description
Changes the point at which a `limit` criterion is applied to a resultset of matching entries.

Current behaviour:
1. Find all related entries matching criteria and tags
2. Sort by `postDate DESC, count DESC`
3. Truncate to `limit`

That means more _recent_ entries take priority over more _relevant_ entries.

New behaviour provided by this PR:
1. Find all related entries matching criteria and tags
2. Sort entries by `count DESC`
3. Truncate entries by `limit`
4. Sort the remaining entries by `postDate DESC`

This makes more _relevant_ entries take priority over more _recent_ entries.

### Related issues
https://github.com/nystudio107/craft-similar/issues/57