### PR TITLE
Redo `limit` and `orderBy` 

### DIFF
--- a/src/services/Similar.php
+++ b/src/services/Similar.php
@@ -68,7 +68,7 @@ class Similar extends Component
         if (!isset($data['context'])) {
             throw new Exception('Required parameter `context` was not supplied to `craft.similar.find`.');
         }
-        
+
         /** @var class-string|Element $element */
         $element = $data['element'];
         $context = $data['context'];
@@ -192,15 +192,7 @@ class Similar extends Component
         $query = $event->sender;
         // Add in the `count` param so we know how many were fetched
         $query->query->addSelect(['COUNT(*) as count']);
-        if (is_array($this->preOrder)) {
-            $this->preOrder = array_filter($this->preOrder, fn($value) => !$value instanceof OrderByPlaceholderExpression);
-            $query->query->orderBy(array_merge([
-                'count' => 'DESC',
-            ], $this->preOrder));
-        } elseif (is_string($this->preOrder)) {
-            $query->query->orderBy('count DESC, ' . str_replace('`', '', $this->preOrder));
-        }
-
+        $query->query->orderBy(array_merge(['count' => SORT_DESC], $query->query->orderBy ?? []));
         $query->query->groupBy(['relations.sourceId', 'elements.id', 'elements_sites.siteId']);
 
         // If targetElements are provided, filter by them, otherwise get anything that matches criteria

--- a/src/services/Similar.php
+++ b/src/services/Similar.php
@@ -68,7 +68,7 @@ class Similar extends Component
         if (!isset($data['context'])) {
             throw new Exception('Required parameter `context` was not supplied to `craft.similar.find`.');
         }
-
+        
         /** @var class-string|Element $element */
         $element = $data['element'];
         $context = $data['context'];
@@ -81,19 +81,12 @@ class Similar extends Component
 
         // Get an ElementQuery for this Element
         $elementClass = is_object($element) ? $element::class : $element;
-
-        // Stash limit and remove from criteria
-        if (isset($criteria['limit'])) {
-            $this->limit = $criteria['limit'];
-            $criteria['limit'] = null;
-        }
-
         /** @var EntryQuery $query */
         $query = $this->getElementQuery($elementClass, $criteria);
 
         // Stash any orderBy directives from the $query for our anonymous function
         $this->preOrder = $query->orderBy ?? [];
-
+        $this->limit = $query->limit;
         // Extract the $tagIds from the $context
         if (is_array($context)) {
             $tagIds = $context;
@@ -189,9 +182,6 @@ class Similar extends Component
             /** @phpstan-ignore-next-line */
             usort($elements, static fn($a, $b) => $a->count < $b->count ? 1 : ($a->count == $b->count ? 0 : -1));
         }
-        if ($this->limit) {
-            $elements = array_slice($elements, 0, $this->limit);
-        }
 
         return $elements;
     }
@@ -219,6 +209,7 @@ class Similar extends Component
         }
 
         $query->subQuery->limit(null); // inner limit to null -> fetch all possible entries, sort them afterwards
+        $query->query->limit($this->limit); // or whatever limit is set
 
         $query->subQuery->groupBy(['elements.id', 'elements_sites.id']);
 


### PR DESCRIPTION
### Description

I'm seeing the same issue #57, with Craft 5 and the following similar template. I believe the new fix from #58 may be a bit overkill for what is a deeper root cause. The real issue I'm seeing is that `count` order is getting rendered to SQL without the desired descending operator. 

This has to do with how the query builder expects arrays of order expressions to be formatted.

> Columns can be specified in either a string (e.g. "id ASC, name DESC") or an array
> (e.g. `['id' => SORT_ASC, 'name' => SORT_DESC]`).

During the `EVENT_AFTER_PREPARE` event where you're modifying the already prepared (or developer provided) `orderBy` clause has gone through normalization and turned into the expected array shape. To prepend to it, you need to use the same sort constants because the array will not be normalized again to turn the string `'DESC'` into the expected `SORT_DESC` constant used by the query builder.

### Related issues

#57, #58.

### Example

```twig
{% set similar = craft.similar.find({
    element: entry,
    context: tags,
    criteria: {
        section: ['events'],
        limit: 6
    }
}) %}
```

This template was getting rendered to SQL as something like (truncated for brevity):

```sql
SELECT `elements`.`id`, `elements_sites`.`siteId`, COUNT(*) AS `count`
FROM ...
GROUP BY `relations`.`sourceId`, `elements`.`id`, `elements_sites`.`siteId`
ORDER BY `count`
LIMIT 6
```

With this new fix, the default order is maintained and the limit still applies to the correctly sorted order. It rendered to SQL like:

```sql
SELECT `elements`.`id`, `elements_sites`.`siteId`, COUNT(*) AS `count`
FROM ...
ORDER BY `count` DESC, `entries`.`postDate` DESC, `elements`.`id` DESC
LIMIT 6
```

This should also keep compatibility with developers that have templates with a query that includes so other non-default order, like `.orderBy('RAND()')` without unnecessary string manipulation.

### Other Workaround

Using an empty string `orderBy` criteria would partially work around the issue but would then not include the default `postDate` and `id` ordering.

```twig
{% set similar = craft.similar.find({
    element: entry,
    context: tags,
    criteria: {
        section: ['events'],
        limit: 6,
        orderBy: ''
    }
}) %}
```